### PR TITLE
Copy npm build directory to output path

### DIFF
--- a/recycle-ics-ui/default.nix
+++ b/recycle-ics-ui/default.nix
@@ -1,8 +1,16 @@
 { lib, buildNpmPackage, fetchFromGitHub, stdenv }:
 
+# See https://zero-to-nix.com/start/nix-build
 buildNpmPackage rec {
   pname = "recycle-ics-ui";
   version = "0.1.0";
+
   src = ./.;
   npmDepsHash = "sha256-18GoVdpMZrYvOdtTrPhSLhPEOpfMOBl40Wj8ddbIwts=";
+
+  installPhase = ''
+    mkdir -p $out
+    npm run build
+    cp -r build/* $out
+  '';
 }

--- a/recycle-ics/recycle-ics.sh
+++ b/recycle-ics/recycle-ics.sh
@@ -2,7 +2,8 @@
 # shellcheck disable=SC3030,SC3024,SC3054
 
 CMD=(cabal run exe:recycle-ics --)
-# CMD=(docker run -p "$PORT:$PORT" recycle:latest)
+# CMD=(docker run -p "$RECYCLE_ICS_PORT:$RECYCLE_ICS_PORT" recycle:latest)
+# CMD=($(nix-build -A recycle-ics)/bin/recycle-ics)
 
 CMD+=(--secret "$RECYCLE_ICS_SECRET")
 


### PR DESCRIPTION
This was merged yesterday, but the nix and docker builds were not working as expected